### PR TITLE
🐛 Fixed RNCWebview version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": ">=6.0.2"
   },
   "dependencies": {
-    "prop-types": "^15.6.2",
-    "react-native-webview": ">=6.0.2"
+    "prop-types": "^15.6.2"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This is to fix a crash happening whenever `react-native-webview` version is updated: 
**Invariant Violation: Tried to register two views with the same name RNCWebView, js engine.**

Replication steps:
- Install a`react-native-webview` version that is `>=6.0.2`
- Update `react-native-webview` to a newer version
- Run the code and try to open Flutterwave's webview

